### PR TITLE
Cleanup DurationUnit enum

### DIFF
--- a/src/clap_support.rs
+++ b/src/clap_support.rs
@@ -23,12 +23,16 @@ use std::time::Duration;
 #[derive(Eq, PartialEq, Debug)]
 pub struct TimeoutDuration(Duration);
 
-///Units in which the duration can be measured. These correspond to [`Duration`]'s `from_` methods.
+/// Units in which the duration can be measured. These correspond to [`Duration`]'s `from_` methods.
 enum DurationUnits {
-    NANOS,
-    MICROS,
-    MILLIS,
-    SECONDS,
+    /// Nanoseconds
+    Nanos,
+    /// Microseconds
+    Micros,
+    /// Milliseconds
+    Millis,
+    /// Seconds
+    Seconds,
 }
 
 impl DurationUnits {
@@ -38,10 +42,10 @@ impl DurationUnits {
     /// * `value` - amount of this unit in the created duration
     fn to_duration(&self, value: u64) -> Duration {
         match self {
-            Self::NANOS => Duration::from_nanos(value),
-            Self::MICROS => Duration::from_micros(value),
-            Self::MILLIS => Duration::from_millis(value),
-            Self::SECONDS => Duration::from_secs(value),
+            Self::Nanos => Duration::from_nanos(value),
+            Self::Micros => Duration::from_micros(value),
+            Self::Millis => Duration::from_millis(value),
+            Self::Seconds => Duration::from_secs(value),
         }
     }
 }
@@ -57,8 +61,8 @@ peg::parser! {
         } / expected!("duration's value is too big")
 
         rule units() -> DurationUnits = quiet! {
-            "ns" { DurationUnits::NANOS } / "us" { DurationUnits::MICROS }
-            / "ms" { DurationUnits::MILLIS } / "s" { DurationUnits::SECONDS }
+            "ns" { DurationUnits::Nanos } / "us" { DurationUnits::Micros }
+            / "ms" { DurationUnits::Millis } / "s" { DurationUnits::Seconds }
         } / expected!("duration's units should be one of \"ms\", \"ns\", \"s\", \"us\"")
 
         /// Parses [`Duration`] from the given [`str`].


### PR DESCRIPTION
# Description

This:
- enables usage of `UpperCamelCase` for enum constants of `DurationUnit` enum
- adds missing docs to its values
- adds missing space to enum's doc