### PR TITLE
Remove `dockerize` job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,24 +39,6 @@ jobs:
         with:
           command: publish
 
-  dockerize:
-    - uses: actions/checkout@v2
-
-    - name: Set environment
-      run: echo "docker_image_tag=${GITHUB_REF##*/v}" >> $GITHUB_ENV
-
-    - uses: docker/login-action@v1.8.0
-      with:
-        username: ${{ secrets.DOCKER_HUB_USERNAME }}
-        password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-    - uses: docker/build-push-action@v2.3.0
-      with:
-        push: true
-        tags: |
-          ${{ secrets.DOCKER_HUB_USERNAME }}/mc-server-pinger:${{ env.docker_image_tag }}
-          ${{ secrets.DOCKER_HUB_USERNAME }}/mc-server-pinger:latest
-
   release:
     strategy:
       matrix:


### PR DESCRIPTION
# Description

This removes `dockerize` job from Release workflow as this job is done by Docker Hub.