### PR TITLE
feat: parse Clap args before starting `async` runtime

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,5 +11,5 @@ pull_request_rules:
       - base=development
     actions:
       queue:
-        method: merge
+        method: squash
         name: dependabot-updates

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,15 +41,21 @@ struct CommandLineOptions {
     flavor: OutputFlavor,
 }
 
+fn main() {
+    let options = CommandLineOptions::parse();
+
+    run(options);
+}
+
 #[tokio::main(flavor = "current_thread")]
-async fn main() {
-    let CommandLineOptions {
+async fn run(
+    CommandLineOptions {
         hostname,
         port,
         timeout,
         flavor,
-    } = CommandLineOptions::parse();
-
+    }: CommandLineOptions,
+) {
     let hostname = hostname.as_str();
 
     match TcpStream::connect((hostname, port)).await {


### PR DESCRIPTION
# Description

This makes it so that `async` runtime is only started when actually needed.

# Trivia

This also fixes Mergify
